### PR TITLE
Add "Refresh Controllers" button to main menu issue/#2125 and issue/#3648

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
@@ -18,6 +18,7 @@ package org.terasology.engine.subsystem.lwjgl;
 import org.lwjgl.LWJGLException;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
+import org.terasology.assets.management.AssetManager;
 import org.terasology.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.config.Config;
 import org.terasology.config.ControllerConfig;
@@ -28,11 +29,14 @@ import org.terasology.input.InputSystem;
 import org.terasology.input.lwjgl.JInputControllerDevice;
 import org.terasology.input.lwjgl.LwjglKeyboardDevice;
 import org.terasology.input.lwjgl.LwjglMouseDevice;
+import org.terasology.rendering.nui.asset.UIElement;
+import org.terasology.rendering.nui.layers.mainMenu.inputSettings.ControllerSettingsScreen;
+
+import java.util.Set;
 
 public class LwjglInput extends BaseLwjglSubsystem {
 
     private Context context;
-
     @Override
     public String getName() {
         return "Input";
@@ -83,5 +87,39 @@ public class LwjglInput extends BaseLwjglSubsystem {
         BindsManager bindsManager = context.get(BindsManager.class);
         bindsManager.updateConfigWithDefaultBinds();
         bindsManager.saveBindsConfig();
+    }
+
+    /**
+     * Refreshes controllers list to discover newly plugged-in controllers
+     * and invalidates the current {@link ControllerSettingsScreen} instance
+     * from current {@link AssetManager} if the screen was already loaded and
+     * saved in the AssetManager.
+     * <p>
+     * Note that: if this {@link LwjglInput} object does not have a {@link Context},
+     * it returns without doing anything. {@link Context} can be initialized by calling
+     * {@code postInitialise(Context rootContext)} ({@see postInitialise}) before calling
+     * this method {@code refreshControllerList}.
+     */
+    public void refreshControllerList(){
+        if (context == null)
+            return;
+
+        // create a new controller device handler.
+        ControllerConfig controllerConfig = context.get(Config.class).getInput().getControllers();
+        JInputControllerDevice controllerDevice = new JInputControllerDevice(controllerConfig);
+        context.get(InputSystem.class).setControllerDevice(controllerDevice);
+
+        // clean thread created by the previous controller environment
+        Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+        for (Thread thread : threadSet) {
+            if (thread.getClass().getName().toLowerCase().equals("net.java.games.input.rawinputeventqueue$queuethread".toLowerCase())) {
+                thread.interrupt();
+            }
+        }
+
+        // invalidate controller page from cache
+        context.get(AssetManager.class).getLoadedAssets(UIElement.class).stream().
+            filter(k -> k.getUrn().equals(ControllerSettingsScreen.ASSET_URI)).
+            forEach(UIElement::dispose);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MainMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MainMenuScreen.java
@@ -18,6 +18,9 @@ package org.terasology.rendering.nui.layers.mainMenu;
 
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.NonNativeJVMDetector;
+import org.terasology.engine.TerasologyEngine;
+import org.terasology.engine.subsystem.EngineSubsystem;
+import org.terasology.engine.subsystem.lwjgl.LwjglInput;
 import org.terasology.i18n.TranslationSystem;
 import org.terasology.identity.storageServiceClient.StorageServiceWorker;
 import org.terasology.identity.storageServiceClient.StorageServiceWorkerStatus;
@@ -87,6 +90,17 @@ public class MainMenuScreen extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "extras", button->triggerForwardAnimation(ExtrasMenuScreen.ASSET_URI));
         WidgetUtil.trySubscribe(this, "exit", button -> engine.shutdown());
         WidgetUtil.trySubscribe(this, "storageServiceAction", widget -> triggerForwardAnimation(PlayerSettingsScreen.ASSET_URI));
+        WidgetUtil.trySubscribe(this, "refreshControllers", button -> {
+            // cast engine to TerasologyEngine.
+            TerasologyEngine terasologyEngine = (TerasologyEngine) engine;
+            // find all subsystems of type LwjglInput and call refreshControllerList on them
+            for (EngineSubsystem subsystem : terasologyEngine.getSubsystems()) {
+                if (subsystem instanceof LwjglInput) {
+                    LwjglInput lwjglInput = (LwjglInput) subsystem;
+                    lwjglInput.refreshControllerList();
+                }
+            }
+        });
     }
 
     private void updateStorageServiceStatus() {

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -443,5 +443,6 @@
     "caching-textures": "caching-textures",
     "loading-prefabs": "loading-prefabs",
     "post-initialise-systems": "post-initialise-systems",
-    "reticulating-splines": "reticulating-splines"
+    "reticulating-splines": "reticulating-splines",
+    "refresh-controllers": "refresh-controllers"
 }

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -456,5 +456,6 @@
     "caching-textures": "Caching Textures...",
     "loading-prefabs": "Loading Prefabs...",
     "post-initialise-systems": "Post-Initialise Systems",
-    "reticulating-splines": "Reticulating Splines"
+    "reticulating-splines": "Reticulating Splines",
+    "refresh-controllers": "Refresh Controllers"
 }

--- a/engine/src/main/resources/assets/ui/menu/mainMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/mainMenuScreen.ui
@@ -104,6 +104,11 @@
                         "text": "${engine:menu#extras-label}"
                     },
                     {
+                        "type": "UIButton",
+                        "id": "refreshControllers",
+                        "text": "${engine:menu#refresh-controllers}"
+                    },
+                    {
                         "type" : "UISpace",
                         "size" : [1, 64]
                     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains
* A "Refresh Controllers" button was added to main menu that partially
solves "recognize disconnect and reconnect" feature in issue/#2125. When
this button is pressed, the list of controllers are re-fetched to be
recognized by the system. This partially solves the problem of having
to close and re-open the game every time a controller is created.

* Also, when this button is pressed, the "Controller Settings" screen is
disposed from the assets. This is done to solve to force the system to re-create
the "Controller Settings" screen in case it had already loaded in the assets
before the "Refresh Controllers" was pressed. This makes the system show the controllers
in the "Controller Settings" screen after re-fetching the controllers. That is why it is related to issue/#3648.

Note that: the re-fetching of controllers was implemented and tested only for windows 10 and Xbox 360 controller. Implementing and testing needs to be done for other operating systems and controllers.

### How to test
Run the game as usual without connecting a controller. You can begin a new game if you want. Then go back to the main menu. Connect a controller. Click on "Refresh Controllers". Then, go to "Settings" -> "Controller Settings" if you want. You should see that the controller options are shown. Then you can go back to the main menu and continue playing using the controller.

**Note that**: when resuming the game in the manner described above, sometimes you need to move the mouse a little bit on the screen and see that player is rotating. Then, begin playing with the controller. I think that it has to do with focus on screen or something like that.

It was a little bit hard to write unit tests to test this feature because it was hard to load native libraries from unit tests.

### Outstanding before merging

- [ ] Need to implement and test for other operating systems (e.g. linux and macOS) and other types of controllers.
- [ ] Need unit tests.
- [ ] Need to have a way to not need the "Refresh Controllers" totally. Maybe JNI is a good option. Or move "Refresh Controllers" button to be in "Controller Settings" menu instead.